### PR TITLE
create list of hosts with at least 1 local admin

### DIFF
--- a/tasks/sets/default-csv.tasks
+++ b/tasks/sets/default-csv.tasks
@@ -35,3 +35,4 @@
 ["GPOs","CSV","GPOs.CSV","Match (n:GPO) return n.name as GPO, n.highvalue as HighValue, n.gpcpath as Path"]
 ["HighValue Group Members","CSV","Groups-HighValue-members.CSV","MATCH p=(n:User)-[r:MemberOf*1..]->(m:Group {highvalue:true}) RETURN n.name as User, m.name as Group"]
 ["Add Use Delegation","CSV","User-AddToGroupDelegation.CSV","MATCH (n:User {admincount:False}) MATCH p=allShortestPaths((n)-[r:AddMember*1..]->(m:Group)) RETURN n.name as User, m.name as Group"]
+["Vulnerable to Local Admin Enumeration","CSV","Hosts_With_More_Than1_Local_Admin.CSV","MATCH p=()-[:AdminTo]->(n:Computer) RETURN n.name as Host, n.operatingsystem as OS"]


### PR DESCRIPTION
Query that creates a list of hosts that are Vulnerable to Local Admin Bloodhound Enumeration. Modern Windows OS fix this vulnerability, such as server 2019 and most versions of windows 10.